### PR TITLE
Fix `vs-version` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You may have a situation where your Actions runner has multiple versions of Visu
 - name: Add msbuild to PATH
   uses: microsoft/setup-msbuild@v1.0.0
     with:
-      vs-version: [16.4,16.5]
+      vs-version: "[16.4,16.5]"
 ```
 
 ## How does this work?


### PR DESCRIPTION
The value needs to be in quotes like it is here: https://github.com/microsoft/setup-msbuild/blob/9c9a1a34a4c6a9f36400e23e479b9c33ec98a4bb/.github/workflows/test.yml#L19