### PR TITLE
Export MSBUILD env variable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,9 @@ async function run(): Promise<void> {
 
     // set the outputs for the action to the folder path of msbuild
     core.setOutput('msbuildPath', toolFolderPath)
+    
+    // also set MSBUILD environment variable in case a tool needs that variable
+    core.exportVariable('MSBUILD', toolFolderPath);
 
     // add tool path to PATH
     core.addPath(toolFolderPath)


### PR DESCRIPTION
I'm using this action to build CPython in an environment with a "scrubbed" PATH, and their build scripts expect an env var named `MSBUILD`.

Would it make sense to export that env var from this action for later steps to use?