### PR TITLE
Path to VSTest.console for running unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,14 @@ jobs:
         echo "vswhere-path: ${{ steps.setup_msbuild_explicit.outputs.msbuildPath }}"
         echo "PATH: ${{ steps.setup_msbuild_path.outputs.msbuildPath }}"
         echo "Fallback: ${{ steps.setup_msbuild_fallback.outputs.msbuildPath }}"
+
+    - name: echo MSBuild
+      run: msbuild -version
+
     - name: echo vstest path
       run: | 
         echo "PATH: ${{ steps.setup_msbuild_path.outputs.vstestPath }}" 
+        
     - name: echo VSTest
       run: | 
         vstest.console --help
-    - name: echo MSBuild
-      run: msbuild -version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,18 @@ jobs:
       id: setup_msbuild_fallback
       uses: ./
       env:
-        PATH: ''
+        PATH: '' 
 
     - name: echo msbuild path
       run: |
         echo "vswhere-path: ${{ steps.setup_msbuild_explicit.outputs.msbuildPath }}"
         echo "PATH: ${{ steps.setup_msbuild_path.outputs.msbuildPath }}"
         echo "Fallback: ${{ steps.setup_msbuild_fallback.outputs.msbuildPath }}"
-
+    - name: echo vstest path
+      run: | 
+        echo "PATH: ${{ steps.setup_msbuild_path.outputs.vstestPath }}" 
+    - name: echo VSTest
+      run: | 
+        vstest.console --help
     - name: echo MSBuild
       run: msbuild -version

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ You know how handy that 'Visual Studio Developer Command Prompt' is on your loca
 
 ```yml
 - name: Add msbuild to PATH
-  uses: microsoft/setup-msbuild@v1.0.1
+  uses: microsoft/setup-msbuild@v1.0.2
 ```
 
 ## Specifying specific versions of Visual Studio
@@ -13,7 +13,7 @@ You may have a situation where your Actions runner has multiple versions of Visu
 
 ```yml
 - name: Add msbuild to PATH
-  uses: microsoft/setup-msbuild@v1.0.1
+  uses: microsoft/setup-msbuild@v1.0.2
   with:
     vs-version: '[16.4,16.5)'
 ```
@@ -25,7 +25,7 @@ This makes use of the vswhere tool which is a tool delivered by Microsoft to hel
 
 ```yml
 - name: Add msbuild to PATH
-  uses: microsoft/setup-msbuild@v1.0.1
+  uses: microsoft/setup-msbuild@v1.0.2
   with:
     vswhere-path: 'C:\path\to\your\tools\'
 ```

--- a/building-release.md
+++ b/building-release.md
@@ -1,0 +1,29 @@
+# Building a release
+This is a quick document to walk through the process of building and releasing.
+
+## Building the version
+- Create a new branch [vMajor.Minor.Revision] for the version from `dev`
+- Make changes in the new branch
+- Build the branch/package
+    - `npm install`
+    - `npm run build`
+    - `npm run package`
+- Prune the dependencies to only production
+    - `npm prune --production`
+- Uncomment `node_modules` in `.gitignore` **for this branch only**
+- Commit the changes to the branch
+- Push the new version branch
+    - `git push origin [vMajor.Minor.Revision]`
+
+## Releasing the new version
+- Draft a new release to [vMajor.Minor.Revision]
+
+## Update major version tag
+If the update is non-breaking and the major version binding you can update the version tag to make the new release available to those binding to the major version tag ([GitHub Actions Versioning](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md)).
+
+Do this from the version branch after push (using a v1 tag as example only here)
+
+```
+git tag -fa v1 -m "Update v1 tag"
+git push origin v1 --force
+```

--- a/dist/index.js
+++ b/dist/index.js
@@ -934,10 +934,72 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
+/***/ 82:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+exports.toCommandValue = toCommandValue;
+//# sourceMappingURL=utils.js.map
+
+/***/ }),
+
 /***/ 87:
 /***/ (function(module) {
 
 module.exports = require("os");
+
+/***/ }),
+
+/***/ 102:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+// For internal use, subject to change.
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fs = __importStar(__webpack_require__(747));
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(82);
+function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}
+exports.issueCommand = issueCommand;
+//# sourceMappingURL=file-command.js.map
 
 /***/ }),
 
@@ -1018,6 +1080,7 @@ function run() {
             }
             core.debug(`Full tool exe: ${vswhereToolExe}`);
             let foundToolPath = '';
+            let foundTestToolPath = '';
             const options = {};
             options.listeners = {
                 stdout: (data) => {
@@ -1032,6 +1095,7 @@ function run() {
                             return;
                         }
                     }
+                    foundTestToolPath = path.join(installationPath, 'Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe');
                     foundToolPath = toolPath;
                 }
             };
@@ -1041,12 +1105,18 @@ function run() {
                 core.setFailed('Unable to find MSBuild.');
                 return;
             }
+            if (!foundTestToolPath) {
+                core.warning('Unable to find VSTest.console');
+            }
             // extract the folder location for the tool
             const toolFolderPath = path.dirname(foundToolPath);
+            const testToolFolderPath = path.dirname(foundTestToolPath);
             // set the outputs for the action to the folder path of msbuild
             core.setOutput('msbuildPath', toolFolderPath);
+            core.setOutput('vstestPath', testToolFolderPath);
             // add tool path to PATH
             core.addPath(toolFolderPath);
+            core.addPath(testToolFolderPath);
             core.debug(`Tool path added to PATH: ${toolFolderPath}`);
         }
         catch (error) {
@@ -1071,17 +1141,25 @@ module.exports = require("assert");
 
 "use strict";
 
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-const os = __webpack_require__(87);
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(82);
 /**
  * Commands
  *
  * Command Format:
- *   ##[name key=value;key=value]message
+ *   ::name key=value,key=value::message
  *
  * Examples:
- *   ##[warning]This is the user warning message
- *   ##[set-secret name=mypassword]definitelyNotAPassword!
+ *   ::warning::This is the message
+ *   ::set-env name=MY_VAR::some value
  */
 function issueCommand(command, properties, message) {
     const cmd = new Command(command, properties, message);
@@ -1106,34 +1184,39 @@ class Command {
         let cmdStr = CMD_STRING + this.command;
         if (this.properties && Object.keys(this.properties).length > 0) {
             cmdStr += ' ';
+            let first = true;
             for (const key in this.properties) {
                 if (this.properties.hasOwnProperty(key)) {
                     const val = this.properties[key];
                     if (val) {
-                        // safely append the val - avoid blowing up when attempting to
-                        // call .replace() if message is not a string for some reason
-                        cmdStr += `${key}=${escape(`${val || ''}`)},`;
+                        if (first) {
+                            first = false;
+                        }
+                        else {
+                            cmdStr += ',';
+                        }
+                        cmdStr += `${key}=${escapeProperty(val)}`;
                     }
                 }
             }
         }
-        cmdStr += CMD_STRING;
-        // safely append the message - avoid blowing up when attempting to
-        // call .replace() if message is not a string for some reason
-        const message = `${this.message || ''}`;
-        cmdStr += escapeData(message);
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
         return cmdStr;
     }
 }
 function escapeData(s) {
-    return s.replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+    return utils_1.toCommandValue(s)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A');
 }
-function escape(s) {
-    return s
+function escapeProperty(s) {
+    return utils_1.toCommandValue(s)
+        .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A')
-        .replace(/]/g, '%5D')
-        .replace(/;/g, '%3B');
+        .replace(/:/g, '%3A')
+        .replace(/,/g, '%2C');
 }
 //# sourceMappingURL=command.js.map
 
@@ -1153,10 +1236,19 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const command_1 = __webpack_require__(431);
-const os = __webpack_require__(87);
-const path = __webpack_require__(622);
+const file_command_1 = __webpack_require__(102);
+const utils_1 = __webpack_require__(82);
+const os = __importStar(__webpack_require__(87));
+const path = __importStar(__webpack_require__(622));
 /**
  * The code to exit an action
  */
@@ -1177,11 +1269,21 @@ var ExitCode;
 /**
  * Sets env variable for this action and future actions in the job
  * @param name the name of the variable to set
- * @param val the value of the variable
+ * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function exportVariable(name, val) {
-    process.env[name] = val;
-    command_1.issueCommand('set-env', { name }, val);
+    const convertedVal = utils_1.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
+    }
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
 }
 exports.exportVariable = exportVariable;
 /**
@@ -1197,7 +1299,13 @@ exports.setSecret = setSecret;
  * @param inputPath
  */
 function addPath(inputPath) {
-    command_1.issueCommand('add-path', {}, inputPath);
+    const filePath = process.env['GITHUB_PATH'] || '';
+    if (filePath) {
+        file_command_1.issueCommand('PATH', inputPath);
+    }
+    else {
+        command_1.issueCommand('add-path', {}, inputPath);
+    }
     process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
 }
 exports.addPath = addPath;
@@ -1220,12 +1328,22 @@ exports.getInput = getInput;
  * Sets the value of an output.
  *
  * @param     name     name of the output to set
- * @param     value    value to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
     command_1.issueCommand('set-output', { name }, value);
 }
 exports.setOutput = setOutput;
+/**
+ * Enables or disables the echoing of commands into stdout for the rest of the step.
+ * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
+ *
+ */
+function setCommandEcho(enabled) {
+    command_1.issue('echo', enabled ? 'on' : 'off');
+}
+exports.setCommandEcho = setCommandEcho;
 //-----------------------------------------------------------------------
 // Results
 //-----------------------------------------------------------------------
@@ -1243,6 +1361,13 @@ exports.setFailed = setFailed;
 // Logging Commands
 //-----------------------------------------------------------------------
 /**
+ * Gets whether Actions Step Debug is on or not
+ */
+function isDebug() {
+    return process.env['RUNNER_DEBUG'] === '1';
+}
+exports.isDebug = isDebug;
+/**
  * Writes debug message to user log
  * @param message debug message
  */
@@ -1252,18 +1377,18 @@ function debug(message) {
 exports.debug = debug;
 /**
  * Adds an error issue
- * @param message error issue message
+ * @param message error issue message. Errors will be converted to string via toString()
  */
 function error(message) {
-    command_1.issue('error', message);
+    command_1.issue('error', message instanceof Error ? message.toString() : message);
 }
 exports.error = error;
 /**
  * Adds an warning issue
- * @param message warning issue message
+ * @param message warning issue message. Errors will be converted to string via toString()
  */
 function warning(message) {
-    command_1.issue('warning', message);
+    command_1.issue('warning', message instanceof Error ? message.toString() : message);
 }
 exports.warning = warning;
 /**
@@ -1321,8 +1446,9 @@ exports.group = group;
  * Saves state for current action, the state can only be retrieved by this action's post job execution.
  *
  * @param     name     name of the state to store
- * @param     value    value to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function saveState(name, value) {
     command_1.issueCommand('save-state', { name }, value);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,6 +59,7 @@ async function run(): Promise<void> {
     core.debug(`Full tool exe: ${vswhereToolExe}`)
 
     let foundToolPath = ''
+    let foundTestToolPath = ''
     const options: ExecOptions = {}
     options.listeners = {
       stdout: (data: Buffer) => {
@@ -68,7 +69,7 @@ async function run(): Promise<void> {
         let toolPath = path.join(
           installationPath,
           'MSBuild\\Current\\Bin\\MSBuild.exe'
-        )
+        )       
 
         core.debug(`Checking for path: ${toolPath}`)
         if (!fs.existsSync(toolPath)) {
@@ -83,6 +84,11 @@ async function run(): Promise<void> {
           }
         }
 
+        foundTestToolPath = path.join(
+          installationPath,
+          'Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe'
+        )
+
         foundToolPath = toolPath
       }
     }
@@ -95,14 +101,21 @@ async function run(): Promise<void> {
       return
     }
 
+    if(!foundTestToolPath){
+      core.warning('Unable to find VSTest.console')
+    }
+
     // extract the folder location for the tool
     const toolFolderPath = path.dirname(foundToolPath)
+    const testToolFolderPath = path.dirname(foundTestToolPath)
 
     // set the outputs for the action to the folder path of msbuild
     core.setOutput('msbuildPath', toolFolderPath)
+    core.setOutput('vstestPath', testToolFolderPath)
 
     // add tool path to PATH
     core.addPath(toolFolderPath)
+    core.addPath(testToolFolderPath)
     core.debug(`Tool path added to PATH: ${toolFolderPath}`)
   } catch (error) {
     core.setFailed(error.message)


### PR DESCRIPTION
Since there is no way to use `msbuild` to run unit tests, it's necessary to add path to `VSTest.Console.exe` or `MSTest.exe`.

But made it only importing **VSTest** because **MSTest** is legacy as described [here](https://docs.microsoft.com/en-us/previous-versions/ms182486(v=vs.140)) and VSTest has better performance.