### PR TITLE
add probing for x64 msbuild binaries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   vs-prerelease:
     description: 'Enable searching for pre-release versions of Visual Studio/MSBuild'
     required: false
+  msbuild-architecture:
+    description: 'The processor architecture to prefer of msbuild. Can be either "x86" or "x64". "x64" is only available from Visual Studio version 17.0 an onwards.'
+    required: false
+    default: 'x86'
 outputs:
   msbuildPath:
     description: 'The resulting location of msbuild for your inputs'

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'Enable searching for pre-release versions of Visual Studio/MSBuild'
     required: false
   msbuild-architecture:
-    description: 'The processor architecture to prefer of msbuild. Can be either "x86" or "x64". "x64" is only available from Visual Studio version 17.0 an onwards.'
+    description: 'The preferred processor architecture of msbuild. Can be either "x86" or "x64". "x64" is only available from Visual Studio version 17.0 and later.'
     required: false
     default: 'x86'
 outputs:

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ const IS_WINDOWS = process.platform === 'win32'
 const VS_VERSION = core.getInput('vs-version') || 'latest'
 const VSWHERE_PATH = core.getInput('vswhere-path')
 const ALLOW_PRERELEASE = core.getInput('vs-prerelease') || 'false'
+const MSBUILD_ARCH = core.getInput('msbuild-architecture') || 'x86';
 
 // if a specific version of VS is requested
 let VSWHERE_EXEC = '-products * -requires Microsoft.Component.MSBuild -property installationPath -latest '
@@ -70,25 +71,38 @@ async function run(): Promise<void> {
         const installationPath = data.toString().trim()
         core.debug(`Found installation path: ${installationPath}`)
 
-        let toolPath = path.join(
-          installationPath,
-          'MSBuild\\Current\\Bin\\MSBuild.exe'
-        )
-
-        core.debug(`Checking for path: ${toolPath}`)
-        if (!fs.existsSync(toolPath)) {
-          toolPath = path.join(
+        // x64 only exists in one possible location, so no fallback probing
+        if(MSBUILD_ARCH === "x64") {
+          let toolPath = path.join(
             installationPath,
-            'MSBuild\\15.0\\Bin\\MSBuild.exe'
-          )
-
+            'MSBuild\\Current\\Bin\\amd64\\MSBuild.exe'
+          );
           core.debug(`Checking for path: ${toolPath}`)
           if (!fs.existsSync(toolPath)) {
             return
           }
-        }
+          foundToolPath = toolPath
+        } else {
+          let toolPath = path.join(
+            installationPath,
+            'MSBuild\\Current\\Bin\\MSBuild.exe'
+          )
 
-        foundToolPath = toolPath
+          core.debug(`Checking for path: ${toolPath}`)
+          if (!fs.existsSync(toolPath)) {
+            toolPath = path.join(
+              installationPath,
+              'MSBuild\\15.0\\Bin\\MSBuild.exe'
+            )
+
+            core.debug(`Checking for path: ${toolPath}`)
+            if (!fs.existsSync(toolPath)) {
+              return
+            }
+          }
+
+          foundToolPath = toolPath
+        }
       }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,7 +72,7 @@ async function run(): Promise<void> {
         core.debug(`Found installation path: ${installationPath}`)
 
         // x64 only exists in one possible location, so no fallback probing
-        if(MSBUILD_ARCH === "x64") {
+        if (MSBUILD_ARCH === "x64") {
           let toolPath = path.join(
             installationPath,
             'MSBuild\\Current\\Bin\\amd64\\MSBuild.exe'


### PR DESCRIPTION
Should address #64, assuming I've done everything correctly. Unsure how to test this, though.  On my vs2022 system, `vswhere.exe -products * -requires Microsoft.Component.MSBuild -property installationPath -latest -prerelease` returns `C:\Program Files\Microsoft Visual Studio\2022\Preview`, and the x64 msbuild can be found inside this directory at `\MSBuild\Current\Bin\amd64\MSBuild.exe`, instead of the x86 binary being found at that same path sans the `amd64`.