### PR TITLE
Support x64 MSBuild on all located VS versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'Enable searching for pre-release versions of Visual Studio/MSBuild'
     required: false
   msbuild-architecture:
-    description: 'The preferred processor architecture of MSBuild. Can be either "x86" or "x64". "x64" is only available from Visual Studio version 17.0 and later.'
+    description: 'The preferred processor architecture of MSBuild. Can be either "x86" or "x64"'
     required: false
     default: 'x86'
 outputs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1090,27 +1090,24 @@ function run() {
                 stdout: (data) => {
                     const installationPath = data.toString().trim();
                     core.debug(`Found installation path: ${installationPath}`);
-                    // x64 only exists in one possible location, so no fallback probing
-                    if (MSBUILD_ARCH === "x64") {
-                        let toolPath = path.join(installationPath, 'MSBuild\\Current\\Bin\\amd64\\MSBuild.exe');
+                    const binSubdirectory = MSBUILD_ARCH === "x64" ?
+                        "Bin/amd64" : "Bin";
+                    let toolPath = path.join(installationPath, 'MSBuild\\Current', binSubdirectory, 'MSBuild.exe');
+                    core.debug(`Checking for path: ${toolPath}`);
+                    if (!fs.existsSync(toolPath)) {
+                        // If the located Visual Studio instance is older than 2019,
+                        // MSBuild's toolset directory was in a versioned subdirectory
+                        // instead of 'Current'.
+                        //
+                        // VSWhere applies only to VS 2017+, so we only have to check
+                        // for '15.0'.
+                        toolPath = path.join(installationPath, 'MSBuild\\15.0', binSubdirectory, 'MSBuild.exe');
                         core.debug(`Checking for path: ${toolPath}`);
                         if (!fs.existsSync(toolPath)) {
                             return;
                         }
-                        foundToolPath = toolPath;
                     }
-                    else {
-                        let toolPath = path.join(installationPath, 'MSBuild\\Current\\Bin\\MSBuild.exe');
-                        core.debug(`Checking for path: ${toolPath}`);
-                        if (!fs.existsSync(toolPath)) {
-                            toolPath = path.join(installationPath, 'MSBuild\\15.0\\Bin\\MSBuild.exe');
-                            core.debug(`Checking for path: ${toolPath}`);
-                            if (!fs.existsSync(toolPath)) {
-                                return;
-                            }
-                        }
-                        foundToolPath = toolPath;
-                    }
+                    foundToolPath = toolPath;
                 }
             };
             // execute the find putting the result of the command in the options foundToolPath

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-msbuild",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Helps set up specific MSBuild tool into PATH for later usage.",
   "main": "lib/main.js",


### PR DESCRIPTION
This is a followup to #65 that extends it a bit:

1. MSBuild has been available in 64-bit for all Visual Studio releases supported by this action, so don't document a limit.
2. Add the fallback to the `15.0` toolsversion location that would be relevant for VS 2017.

cc @baronfel