### PR TITLE
Fixes #104 reassigning input arg [skip ci]

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1652,7 +1652,7 @@ const IS_WINDOWS = process.platform === 'win32';
 const VS_VERSION = core.getInput('vs-version') || 'latest';
 const VSWHERE_PATH = core.getInput('vswhere-path');
 const ALLOW_PRERELEASE = core.getInput('vs-prerelease') || 'false';
-const MSBUILD_ARCH = core.getInput('msbuild-architecture') || 'x86';
+let MSBUILD_ARCH = core.getInput('msbuild-architecture') || 'x86';
 // if a specific version of VS is requested
 let VSWHERE_EXEC = '-products * -requires Microsoft.Component.MSBuild -property installationPath -latest ';
 if (ALLOW_PRERELEASE === 'true') {
@@ -1703,6 +1703,10 @@ function run() {
                     core.debug(`Found installation path: ${installationPath}`);
                     // x64 and arm64 only exist in one possible location, so no fallback probing
                     if (MSBUILD_ARCH === 'x64' || MSBUILD_ARCH === 'arm64') {
+                        // x64 is actually amd64 so change to that
+                        if (MSBUILD_ARCH === 'x64') {
+                            MSBUILD_ARCH = 'amd64';
+                        }
                         let toolPath = path.join(installationPath, `MSBuild\\Current\\Bin\\${MSBUILD_ARCH}\\MSBuild.exe`);
                         core.debug(`Checking for path: ${toolPath}`);
                         if (!fs.existsSync(toolPath)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ const IS_WINDOWS = process.platform === 'win32'
 const VS_VERSION = core.getInput('vs-version') || 'latest'
 const VSWHERE_PATH = core.getInput('vswhere-path')
 const ALLOW_PRERELEASE = core.getInput('vs-prerelease') || 'false'
-const MSBUILD_ARCH = core.getInput('msbuild-architecture') || 'x86'
+let MSBUILD_ARCH = core.getInput('msbuild-architecture') || 'x86'
 
 // if a specific version of VS is requested
 let VSWHERE_EXEC = '-products * -requires Microsoft.Component.MSBuild -property installationPath -latest '
@@ -73,6 +73,10 @@ async function run(): Promise<void> {
 
         // x64 and arm64 only exist in one possible location, so no fallback probing
         if (MSBUILD_ARCH === 'x64' || MSBUILD_ARCH === 'arm64') {
+          // x64 is actually amd64 so change to that
+          if (MSBUILD_ARCH === 'x64') {
+            MSBUILD_ARCH = 'amd64'
+          }
           let toolPath = path.join(
             installationPath,
             `MSBuild\\Current\\Bin\\${MSBUILD_ARCH}\\MSBuild.exe`


### PR DESCRIPTION
Fixes #104 as `x64` isn't a real path and we missed in CR that it previously mapped to `amd64`