### PR TITLE
Set default architecture of msbuild to x64 if running on 64bit machine

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,8 @@ inputs:
     description: 'Enable searching for pre-release versions of Visual Studio/MSBuild'
     required: false
   msbuild-architecture:
-    description: 'The preferred processor architecture of MSBuild. Can be either "x86", "x64", or "arm64". "x64" is only available from Visual Studio version 17.0 and later.'
+    description: 'The preferred processor architecture of MSBuild. Can be either "x86", "x64", or "arm64". "x64" is only available from Visual Studio version 17.0 and later.'. If empty, it will be auto-detected
     required: false
-    default: 'x86'
 outputs:
   msbuildPath:
     description: 'The resulting location of msbuild for your inputs'

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'Enable searching for pre-release versions of Visual Studio/MSBuild'
     required: false
   msbuild-architecture:
-    description: 'The preferred processor architecture of MSBuild. Can be either "x86", "x64", or "arm64". "x64" is only available from Visual Studio version 17.0 and later.'. If empty, it will be auto-detected
+    description: 'The preferred processor architecture of MSBuild. Can be either "x86", "x64", or "arm64". "x64" is only available from Visual Studio version 17.0 and later. If empty, it will be auto-detected'
     required: false
 outputs:
   msbuildPath:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1642,17 +1642,26 @@ var __importStar = (this && this.__importStar) || function (mod) {
     result["default"] = mod;
     return result;
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const exec = __importStar(__webpack_require__(986));
 const fs = __importStar(__webpack_require__(747));
 const path = __importStar(__webpack_require__(622));
 const io = __importStar(__webpack_require__(1));
+const os_1 = __importDefault(__webpack_require__(87));
 const IS_WINDOWS = process.platform === 'win32';
 const VS_VERSION = core.getInput('vs-version') || 'latest';
 const VSWHERE_PATH = core.getInput('vswhere-path');
 const ALLOW_PRERELEASE = core.getInput('vs-prerelease') || 'false';
-let MSBUILD_ARCH = core.getInput('msbuild-architecture') || 'x86';
+function is64Bit() {
+    // as of writing, these architectures returned by os.arch are 64bit
+    return ['arm64', 'ppc64', 'x64', 's390x'].includes(os_1.default.arch());
+}
+let DEFAULT_ARCH = is64Bit() ? 'x64' : 'x86';
+let MSBUILD_ARCH = core.getInput('msbuild-architecture') || DEFAULT_ARCH;
 // if a specific version of VS is requested
 let VSWHERE_EXEC = '-products * -requires Microsoft.Component.MSBuild -property installationPath -latest ';
 if (ALLOW_PRERELEASE === 'true') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "setup-msbuild",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-msbuild",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.0.3",
-        "@actions/tool-cache": "^1.3.0"
+        "@actions/tool-cache": "^1.3.0",
+        "os": "^0.1.2"
       },
       "devDependencies": {
         "@types/jest": "^24.0.23",
@@ -6075,6 +6076,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/os": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
+      "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ=="
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
@@ -13130,6 +13136,11 @@
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
       }
+    },
+    "os": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
+      "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ=="
     },
     "os-tmpdir": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.0.3",
-    "@actions/tool-cache": "^1.3.0"
+    "@actions/tool-cache": "^1.3.0",
+    "os": "^0.1.2"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,21 @@ import * as exec from '@actions/exec'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as io from '@actions/io'
+import Os from 'os'
 import {ExecOptions} from '@actions/exec/lib/interfaces'
 
 const IS_WINDOWS = process.platform === 'win32'
 const VS_VERSION = core.getInput('vs-version') || 'latest'
 const VSWHERE_PATH = core.getInput('vswhere-path')
 const ALLOW_PRERELEASE = core.getInput('vs-prerelease') || 'false'
-let MSBUILD_ARCH = core.getInput('msbuild-architecture') || 'x86'
+
+function is64Bit() {  
+  // as of writing, these architectures returned by os.arch are 64bit
+  return ['arm64', 'ppc64', 'x64', 's390x'].includes(Os.arch())
+}
+
+let DEFAULT_ARCH = is64Bit() ? 'x64' : 'x86';
+let MSBUILD_ARCH = core.getInput('msbuild-architecture') || DEFAULT_ARCH
 
 // if a specific version of VS is requested
 let VSWHERE_EXEC = '-products * -requires Microsoft.Component.MSBuild -property installationPath -latest '


### PR DESCRIPTION
This addresses #88.

The `msbuild-architecture` parameter defined in the `yml` no longer defaults to 'x86' and instead can be empty. If so, the typescript code now detects if the OS is 64bit (by using Os.arch() - https://nodejs.org/api/os.html#osarch), and if so sets the default architecture to x64 (or should it be `amd64`?). 

It works on my 64 bit build machines, but I don't have any other architectures to test this on, but it should be perfectly fine and not have any issues whatsoever, right? Maybe it's worth tagging this as `v2-beta` or something and give people the opportunity to opt in for a while to make sure it's ok.