### PR TITLE
Allow action to run on other platforms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "setup-msbuild",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-msbuild",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@actions/exec": "^1.0.3",
-        "@actions/tool-cache": "^1.3.0"
+        "@actions/exec": "^1.1.1",
+        "@actions/io": "^1.1.3"
       },
       "devDependencies": {
         "@types/jest": "^24.0.23",
@@ -55,38 +55,17 @@
       }
     },
     "node_modules/@actions/exec": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.3.tgz",
-      "integrity": "sha512-TogJGnueOmM7ntCi0ASTUj4LapRRtDfj57Ja4IhPmg2fls28uVOPbAn8N+JifaOumN2UG3oEO/Ixek2A4NcYSA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "dependencies": {
         "@actions/io": "^1.0.1"
       }
     },
-    "node_modules/@actions/http-client": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
-      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
-      "dependencies": {
-        "tunnel": "0.0.6"
-      }
-    },
     "node_modules/@actions/io": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
-      "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
-    },
-    "node_modules/@actions/tool-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.3.0.tgz",
-      "integrity": "sha512-pbv32I89niDShw1YTDo0OFQmWPkZPElE7e3So1jfEzjIyzGRfYIzshwOVhemJZLcDtzo3kxO3GFDAmuVvub/6w==",
-      "dependencies": {
-        "@actions/core": "^1.2.0",
-        "@actions/exec": "^1.0.0",
-        "@actions/http-client": "^1.0.1",
-        "@actions/io": "^1.0.1",
-        "semver": "^6.1.0",
-        "uuid": "^3.3.2"
-      }
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.5.5",
@@ -6901,6 +6880,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -7866,6 +7846,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -8206,38 +8187,17 @@
       }
     },
     "@actions/exec": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.3.tgz",
-      "integrity": "sha512-TogJGnueOmM7ntCi0ASTUj4LapRRtDfj57Ja4IhPmg2fls28uVOPbAn8N+JifaOumN2UG3oEO/Ixek2A4NcYSA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "requires": {
         "@actions/io": "^1.0.1"
       }
     },
-    "@actions/http-client": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
-      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
-      "requires": {
-        "tunnel": "0.0.6"
-      }
-    },
     "@actions/io": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
-      "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
-    },
-    "@actions/tool-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.3.0.tgz",
-      "integrity": "sha512-pbv32I89niDShw1YTDo0OFQmWPkZPElE7e3So1jfEzjIyzGRfYIzshwOVhemJZLcDtzo3kxO3GFDAmuVvub/6w==",
-      "requires": {
-        "@actions/core": "^1.2.0",
-        "@actions/exec": "^1.0.0",
-        "@actions/http-client": "^1.0.1",
-        "@actions/io": "^1.0.1",
-        "semver": "^6.1.0",
-        "uuid": "^3.3.2"
-      }
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
     },
     "@babel/code-frame": {
       "version": "7.5.5",
@@ -13770,7 +13730,8 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -14552,7 +14513,8 @@
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@actions/exec": "^1.0.3",
-    "@actions/tool-cache": "^1.3.0"
+    "@actions/exec": "^1.1.1",
+    "@actions/io": "^1.1.3"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,10 +12,11 @@ const ALLOW_PRERELEASE = core.getInput('vs-prerelease') || 'false'
 let MSBUILD_ARCH = core.getInput('msbuild-architecture') || 'x86'
 
 // if a specific version of VS is requested
-let VSWHERE_EXEC = '-products * -requires Microsoft.Component.MSBuild -property installationPath -latest '
+let VSWHERE_EXEC =
+  '-products * -requires Microsoft.Component.MSBuild -property installationPath -latest '
 if (ALLOW_PRERELEASE === 'true') {
-    VSWHERE_EXEC += ' -prerelease '
- }
+  VSWHERE_EXEC += ' -prerelease '
+}
 
 if (VS_VERSION !== 'latest') {
   VSWHERE_EXEC += `-version "${VS_VERSION}" `
@@ -77,7 +78,7 @@ async function run(): Promise<void> {
           if (MSBUILD_ARCH === 'x64') {
             MSBUILD_ARCH = 'amd64'
           }
-          let toolPath = path.join(
+          const toolPath = path.join(
             installationPath,
             `MSBuild\\Current\\Bin\\${MSBUILD_ARCH}\\MSBuild.exe`
           )

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,11 @@ async function run(): Promise<void> {
     core.addPath(toolFolderPath)
     core.debug(`Tool path added to PATH: ${toolFolderPath}`)
   } catch (error) {
-    core.setFailed(error.message)
+    if (error instanceof Error) {
+      core.setFailed(error.message)
+    } else {
+      core.setFailed('Unknown error')
+    }
   }
 }
 

--- a/src/vs-ver.ts
+++ b/src/vs-ver.ts
@@ -1,0 +1,48 @@
+export function lt(
+  a: [number, number, number, number],
+  b: [number, number, number, number]
+): boolean {
+  for (let index = 0; index < 4; index++) {
+    if (a[index] < b[index]) {
+      return true
+    } else if (a[index] > b[index]) {
+      return false
+    }
+  }
+  return false
+}
+
+export function lte(
+  a: [number, number, number, number],
+  b: [number, number, number, number]
+): boolean {
+  return !gt(a, b)
+}
+
+export function gt(
+  a: [number, number, number, number],
+  b: [number, number, number, number]
+): boolean {
+  for (let index = 0; index < 4; index++) {
+    if (a[index] > b[index]) {
+      return true
+    } else if (a[index] < b[index]) {
+      return false
+    }
+  }
+  return false
+}
+
+export function gte(
+  a: [number, number, number, number],
+  b: [number, number, number, number]
+): boolean {
+  return !lt(a, b)
+}
+
+export function eq(
+  a: [number, number, number, number],
+  b: [number, number, number, number]
+): boolean {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3]
+}


### PR DESCRIPTION
In order to allow simpler workflow writing this allows to run the action on all platforms.
This checks if msbuild is already in path (for github-hosted Ubuntu and MacOS runners it is).
If it is and the version matches with the one specified (always if "latest") the action simply terminates and does nothing, otherwise it fails as before.
Behavior on Windows is not changed.

On a side note, I fixed a couple of Typescript and Eslint errors